### PR TITLE
Fix hyphenated vips options incorrectly being used with Java-style names

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation("app.photofox.vips-ffm:vips-ffm-core:0.5.0")
+    implementation("app.photofox.vips-ffm:vips-ffm-core:0.5.1")
 }
 ```
 

--- a/core/src/main/java/app/photofox/vipsffm/VImage.java
+++ b/core/src/main/java/app/photofox/vipsffm/VImage.java
@@ -469,7 +469,7 @@ public final class VImage {
   public VImage bandbool(VipsOperationBoolean boolean1, VipsOption... args) throws VipsError {
     var inOption = VipsOption.Image("in", this);
     var outOption = VipsOption.Image("out");
-    var boolean1Option = VipsOption.Enum("boolean1", boolean1);
+    var boolean1Option = VipsOption.Enum("boolean", boolean1);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(inOption);
     callArgs.add(outOption);
@@ -598,7 +598,7 @@ public final class VImage {
     var leftOption = VipsOption.Image("left", this);
     var rightOption = VipsOption.Image("right", this);
     var outOption = VipsOption.Image("out");
-    var boolean1Option = VipsOption.Enum("boolean1", boolean1);
+    var boolean1Option = VipsOption.Enum("boolean", boolean1);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(leftOption);
     callArgs.add(rightOption);
@@ -618,7 +618,7 @@ public final class VImage {
       throws VipsError {
     var inOption = VipsOption.Image("in", this);
     var outOption = VipsOption.Image("out");
-    var boolean1Option = VipsOption.Enum("boolean1", boolean1);
+    var boolean1Option = VipsOption.Enum("boolean", boolean1);
     var cOption = VipsOption.ArrayDouble("c", c);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(inOption);
@@ -1773,7 +1773,7 @@ public final class VImage {
     var outOption = VipsOption.Image("out");
     var widthOption = VipsOption.Int("width", width);
     var heightOption = VipsOption.Int("height", height);
-    var fractalDimensionOption = VipsOption.Double("fractalDimension", fractalDimension);
+    var fractalDimensionOption = VipsOption.Double("fractal-dimension", fractalDimension);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
     callArgs.add(widthOption);
@@ -1859,7 +1859,7 @@ public final class VImage {
   public VImage gaussmat(double sigma, double minAmpl, VipsOption... args) throws VipsError {
     var outOption = VipsOption.Image("out");
     var sigmaOption = VipsOption.Double("sigma", sigma);
-    var minAmplOption = VipsOption.Double("minAmpl", minAmpl);
+    var minAmplOption = VipsOption.Double("min-ampl", minAmpl);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
     callArgs.add(sigmaOption);
@@ -1897,7 +1897,7 @@ public final class VImage {
    */
   public List<Double> getpoint(int x, int y, VipsOption... args) throws VipsError {
     var inOption = VipsOption.Image("in", this);
-    var outArrayOption = VipsOption.ArrayDouble("outArray");
+    var outArrayOption = VipsOption.ArrayDouble("out-array");
     var xOption = VipsOption.Int("x", x);
     var yOption = VipsOption.Int("y", y);
     var callArgs = new ArrayList<>(Arrays.asList(args));
@@ -2136,7 +2136,7 @@ public final class VImage {
   public VImage grid(int tileHeight, int across, int down, VipsOption... args) throws VipsError {
     var inOption = VipsOption.Image("in", this);
     var outOption = VipsOption.Image("out");
-    var tileHeightOption = VipsOption.Int("tileHeight", tileHeight);
+    var tileHeightOption = VipsOption.Int("tile-height", tileHeight);
     var acrossOption = VipsOption.Int("across", across);
     var downOption = VipsOption.Int("down", down);
     var callArgs = new ArrayList<>(Arrays.asList(args));
@@ -2568,7 +2568,7 @@ public final class VImage {
   public VImage iccTransform(String outputProfile, VipsOption... args) throws VipsError {
     var inOption = VipsOption.Image("in", this);
     var outOption = VipsOption.Image("out");
-    var outputProfileOption = VipsOption.String("outputProfile", outputProfile);
+    var outputProfileOption = VipsOption.String("output-profile", outputProfile);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(inOption);
     callArgs.add(outOption);
@@ -3244,7 +3244,7 @@ public final class VImage {
   public VImage logmat(double sigma, double minAmpl, VipsOption... args) throws VipsError {
     var outOption = VipsOption.Image("out");
     var sigmaOption = VipsOption.Double("sigma", sigma);
-    var minAmplOption = VipsOption.Double("minAmpl", minAmpl);
+    var minAmplOption = VipsOption.Double("min-ampl", minAmpl);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
     callArgs.add(sigmaOption);
@@ -3411,8 +3411,8 @@ public final class VImage {
     var widthOption = VipsOption.Int("width", width);
     var heightOption = VipsOption.Int("height", height);
     var orderOption = VipsOption.Double("order", order);
-    var frequencyCutoffOption = VipsOption.Double("frequencyCutoff", frequencyCutoff);
-    var amplitudeCutoffOption = VipsOption.Double("amplitudeCutoff", amplitudeCutoff);
+    var frequencyCutoffOption = VipsOption.Double("frequency-cutoff", frequencyCutoff);
+    var amplitudeCutoffOption = VipsOption.Double("amplitude-cutoff", amplitudeCutoff);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
     callArgs.add(widthOption);
@@ -3446,10 +3446,10 @@ public final class VImage {
     var widthOption = VipsOption.Int("width", width);
     var heightOption = VipsOption.Int("height", height);
     var orderOption = VipsOption.Double("order", order);
-    var frequencyCutoffXOption = VipsOption.Double("frequencyCutoffX", frequencyCutoffX);
-    var frequencyCutoffYOption = VipsOption.Double("frequencyCutoffY", frequencyCutoffY);
+    var frequencyCutoffXOption = VipsOption.Double("frequency-cutoff-x", frequencyCutoffX);
+    var frequencyCutoffYOption = VipsOption.Double("frequency-cutoff-y", frequencyCutoffY);
     var radiusOption = VipsOption.Double("radius", radius);
-    var amplitudeCutoffOption = VipsOption.Double("amplitudeCutoff", amplitudeCutoff);
+    var amplitudeCutoffOption = VipsOption.Double("amplitude-cutoff", amplitudeCutoff);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
     callArgs.add(widthOption);
@@ -3483,8 +3483,8 @@ public final class VImage {
     var widthOption = VipsOption.Int("width", width);
     var heightOption = VipsOption.Int("height", height);
     var orderOption = VipsOption.Double("order", order);
-    var frequencyCutoffOption = VipsOption.Double("frequencyCutoff", frequencyCutoff);
-    var amplitudeCutoffOption = VipsOption.Double("amplitudeCutoff", amplitudeCutoff);
+    var frequencyCutoffOption = VipsOption.Double("frequency-cutoff", frequencyCutoff);
+    var amplitudeCutoffOption = VipsOption.Double("amplitude-cutoff", amplitudeCutoff);
     var ringwidthOption = VipsOption.Double("ringwidth", ringwidth);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
@@ -3514,7 +3514,7 @@ public final class VImage {
     var outOption = VipsOption.Image("out");
     var widthOption = VipsOption.Int("width", width);
     var heightOption = VipsOption.Int("height", height);
-    var fractalDimensionOption = VipsOption.Double("fractalDimension", fractalDimension);
+    var fractalDimensionOption = VipsOption.Double("fractal-dimension", fractalDimension);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
     callArgs.add(widthOption);
@@ -3541,8 +3541,8 @@ public final class VImage {
     var outOption = VipsOption.Image("out");
     var widthOption = VipsOption.Int("width", width);
     var heightOption = VipsOption.Int("height", height);
-    var frequencyCutoffOption = VipsOption.Double("frequencyCutoff", frequencyCutoff);
-    var amplitudeCutoffOption = VipsOption.Double("amplitudeCutoff", amplitudeCutoff);
+    var frequencyCutoffOption = VipsOption.Double("frequency-cutoff", frequencyCutoff);
+    var amplitudeCutoffOption = VipsOption.Double("amplitude-cutoff", amplitudeCutoff);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
     callArgs.add(widthOption);
@@ -3573,10 +3573,10 @@ public final class VImage {
     var outOption = VipsOption.Image("out");
     var widthOption = VipsOption.Int("width", width);
     var heightOption = VipsOption.Int("height", height);
-    var frequencyCutoffXOption = VipsOption.Double("frequencyCutoffX", frequencyCutoffX);
-    var frequencyCutoffYOption = VipsOption.Double("frequencyCutoffY", frequencyCutoffY);
+    var frequencyCutoffXOption = VipsOption.Double("frequency-cutoff-x", frequencyCutoffX);
+    var frequencyCutoffYOption = VipsOption.Double("frequency-cutoff-y", frequencyCutoffY);
     var radiusOption = VipsOption.Double("radius", radius);
-    var amplitudeCutoffOption = VipsOption.Double("amplitudeCutoff", amplitudeCutoff);
+    var amplitudeCutoffOption = VipsOption.Double("amplitude-cutoff", amplitudeCutoff);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
     callArgs.add(widthOption);
@@ -3607,8 +3607,8 @@ public final class VImage {
     var outOption = VipsOption.Image("out");
     var widthOption = VipsOption.Int("width", width);
     var heightOption = VipsOption.Int("height", height);
-    var frequencyCutoffOption = VipsOption.Double("frequencyCutoff", frequencyCutoff);
-    var amplitudeCutoffOption = VipsOption.Double("amplitudeCutoff", amplitudeCutoff);
+    var frequencyCutoffOption = VipsOption.Double("frequency-cutoff", frequencyCutoff);
+    var amplitudeCutoffOption = VipsOption.Double("amplitude-cutoff", amplitudeCutoff);
     var ringwidthOption = VipsOption.Double("ringwidth", ringwidth);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
@@ -3637,7 +3637,7 @@ public final class VImage {
     var outOption = VipsOption.Image("out");
     var widthOption = VipsOption.Int("width", width);
     var heightOption = VipsOption.Int("height", height);
-    var frequencyCutoffOption = VipsOption.Double("frequencyCutoff", frequencyCutoff);
+    var frequencyCutoffOption = VipsOption.Double("frequency-cutoff", frequencyCutoff);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
     callArgs.add(widthOption);
@@ -3665,8 +3665,8 @@ public final class VImage {
     var outOption = VipsOption.Image("out");
     var widthOption = VipsOption.Int("width", width);
     var heightOption = VipsOption.Int("height", height);
-    var frequencyCutoffXOption = VipsOption.Double("frequencyCutoffX", frequencyCutoffX);
-    var frequencyCutoffYOption = VipsOption.Double("frequencyCutoffY", frequencyCutoffY);
+    var frequencyCutoffXOption = VipsOption.Double("frequency-cutoff-x", frequencyCutoffX);
+    var frequencyCutoffYOption = VipsOption.Double("frequency-cutoff-y", frequencyCutoffY);
     var radiusOption = VipsOption.Double("radius", radius);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);
@@ -3696,7 +3696,7 @@ public final class VImage {
     var outOption = VipsOption.Image("out");
     var widthOption = VipsOption.Int("width", width);
     var heightOption = VipsOption.Int("height", height);
-    var frequencyCutoffOption = VipsOption.Double("frequencyCutoff", frequencyCutoff);
+    var frequencyCutoffOption = VipsOption.Double("frequency-cutoff", frequencyCutoff);
     var ringwidthOption = VipsOption.Double("ringwidth", ringwidth);
     var callArgs = new ArrayList<>(Arrays.asList(args));
     callArgs.add(outOption);

--- a/generator/src/main/kotlin/vipsffm/GenerateVClasses.kt
+++ b/generator/src/main/kotlin/vipsffm/GenerateVClasses.kt
@@ -219,18 +219,18 @@ object GenerateVClasses {
             val poetArgType = poetArg.type
             val vipsOptionType = mapPoetTypeToVipsOptionType(poetArgType, argSpec)
             if (argSpec.isOutput) {
-                method.addStatement("var ${poetArg.name}Option = \$T(\"${poetArg.name}\")", vipsOptionType)
+                method.addStatement("var ${poetArg.name}Option = \$T(\"${argSpec.name}\")", vipsOptionType)
             } else if (argSpec.isInput) {
                 if (poetArg.type == vimageType) {
-                    method.addStatement("var ${poetArg.name}Option = \$T(\"${poetArg.name}\", this)", vipsOptionType)
+                    method.addStatement("var ${poetArg.name}Option = \$T(\"${argSpec.name}\", this)", vipsOptionType)
                 } else if (poetArg.type == vEnumType) {
                     method.addStatement(
-                        "var ${poetArg.name}Option = \$T(\"${poetArg.name}\", ${poetArg.name}.getRawValue())",
+                        "var ${poetArg.name}Option = \$T(\"${argSpec.name}\", ${poetArg.name}.getRawValue())",
                         vipsOptionType
                     )
                 } else {
                     method.addStatement(
-                        "var ${poetArg.name}Option = \$T(\"${poetArg.name}\", ${poetArg.name})",
+                        "var ${poetArg.name}Option = \$T(\"${argSpec.name}\", ${poetArg.name})",
                         vipsOptionType
                     )
                 }

--- a/sample/src/main/kotlin/vipsffm/SampleRunner.kt
+++ b/sample/src/main/kotlin/vipsffm/SampleRunner.kt
@@ -1,9 +1,7 @@
 package vipsffm
 
 import app.photofox.vipsffm.Vips
-import app.photofox.vipsffm.VipsHelper
 import org.slf4j.LoggerFactory
-import java.lang.foreign.Arena
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.Locale
@@ -21,7 +19,8 @@ object SampleRunner {
             VImageCreateThumbnailSample,
             VImageChainSample,
             VSourceTargetSample,
-            VImageCopyWriteSample
+            VImageCopyWriteSample,
+            VOptionHyphenSample
         )
         val sampleParentRunPath = Paths.get("sample_run")
         if (Files.exists(sampleParentRunPath)) {

--- a/sample/src/main/kotlin/vipsffm/VOptionHyphenSample.kt
+++ b/sample/src/main/kotlin/vipsffm/VOptionHyphenSample.kt
@@ -1,0 +1,28 @@
+package vipsffm
+
+import app.photofox.vipsffm.VImage
+import java.lang.foreign.Arena
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+
+object VOptionHyphenSample: RunnableSample {
+
+    // https://github.com/lopcode/vips-ffm/issues/60
+    // tests a vips operation with a hyphenated option name ("output-profile") in icc_transform
+    override fun run(arena: Arena, workingDirectory: Path): Result<Unit> {
+        val outputPath = workingDirectory.resolve("rabbit_chain.jpg")
+        val image = VImage.newFromFile(
+            arena,
+            "sample/src/main/resources/sample_images/rabbit.jpg"
+        )
+            .thumbnailImage(400)
+            .iccTransform("cmyk")
+
+        image.writeToFile(outputPath.absolutePathString())
+
+        return SampleHelper.validate(
+            outputPath,
+            expectedSizeBoundsKb = 750L..1500L
+        )
+    }
+}


### PR DESCRIPTION
As raised in #60 - when specifying Vips options, we should use the original arg spec name, and not the Java-style name.