### PR TITLE
Fix bug causing VipsBlob types to get refcounted as objects instead of areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation("app.photofox.vips-ffm:vips-ffm-core:0.5.4")
+    implementation("app.photofox.vips-ffm:vips-ffm-core:0.5.5")
 }
 ```
 

--- a/core/src/main/java/app/photofox/vipsffm/VipsHelper.java
+++ b/core/src/main/java/app/photofox/vipsffm/VipsHelper.java
@@ -771,6 +771,37 @@ public final class VipsHelper {
   /**
    * Binding for:
    * {@snippet lang=c :
+   * VipsArea *vips_area_copy(VipsArea *area)
+   * }
+   */
+  public static MemorySegment area_copy(Arena arena, MemorySegment area) throws VipsError {
+    if(!VipsValidation.isValidPointer(area)) {
+      VipsValidation.throwInvalidInputError("vips_area_copy", "area");
+    }
+    var result = VipsRaw.vips_area_copy(area);
+    if(!VipsValidation.isValidPointer(result)) {
+      VipsValidation.throwInvalidOutputError("vips_area_copy", "result");
+    }
+    result = result.reinterpret(arena, VipsRaw::g_object_unref);
+    return result;
+  }
+
+  /**
+   * Binding for:
+   * {@snippet lang=c :
+   * void vips_area_unref(VipsArea *area)
+   * }
+   */
+  public static void area_unref(MemorySegment area) throws VipsError {
+    if(!VipsValidation.isValidPointer(area)) {
+      VipsValidation.throwInvalidInputError("vips_area_unref", "area");
+    }
+    VipsRaw.vips_area_unref(area);
+  }
+
+  /**
+   * Binding for:
+   * {@snippet lang=c :
    * VipsBlob *vips_blob_new(VipsCallbackFn free_fn, const void *data, size_t length)
    * }
    */

--- a/core/src/main/java/app/photofox/vipsffm/jextract/VipsRaw.java
+++ b/core/src/main/java/app/photofox/vipsffm/jextract/VipsRaw.java
@@ -14468,6 +14468,121 @@ public class VipsRaw {
         }
     }
 
+    private static class vips_area_copy {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            VipsRaw.C_POINTER,
+            VipsRaw.C_POINTER
+        );
+
+        public static final MemorySegment ADDR = VipsRaw.findOrThrow("vips_area_copy");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * extern VipsArea *vips_area_copy(VipsArea *area)
+     * }
+     */
+    public static FunctionDescriptor vips_area_copy$descriptor() {
+        return vips_area_copy.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * extern VipsArea *vips_area_copy(VipsArea *area)
+     * }
+     */
+    public static MethodHandle vips_area_copy$handle() {
+        return vips_area_copy.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * extern VipsArea *vips_area_copy(VipsArea *area)
+     * }
+     */
+    public static MemorySegment vips_area_copy$address() {
+        return vips_area_copy.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * extern VipsArea *vips_area_copy(VipsArea *area)
+     * }
+     */
+    public static MemorySegment vips_area_copy(MemorySegment area) {
+        var mh$ = vips_area_copy.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("vips_area_copy", area);
+            }
+            return (MemorySegment)mh$.invokeExact(area);
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class vips_area_unref {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
+            VipsRaw.C_POINTER
+        );
+
+        public static final MemorySegment ADDR = VipsRaw.findOrThrow("vips_area_unref");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * extern void vips_area_unref(VipsArea *area)
+     * }
+     */
+    public static FunctionDescriptor vips_area_unref$descriptor() {
+        return vips_area_unref.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * extern void vips_area_unref(VipsArea *area)
+     * }
+     */
+    public static MethodHandle vips_area_unref$handle() {
+        return vips_area_unref.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * extern void vips_area_unref(VipsArea *area)
+     * }
+     */
+    public static MemorySegment vips_area_unref$address() {
+        return vips_area_unref.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * extern void vips_area_unref(VipsArea *area)
+     * }
+     */
+    public static void vips_area_unref(MemorySegment area) {
+        var mh$ = vips_area_unref.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("vips_area_unref", area);
+            }
+            mh$.invokeExact(area);
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
     private static class vips_blob_new {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             VipsRaw.C_POINTER,

--- a/generate_ffm_bindings.sh
+++ b/generate_ffm_bindings.sh
@@ -47,7 +47,7 @@ rm includes_filtered.txt || true
 touch includes_filtered.txt
 
 {
-  grep -iE ' (_)?(vips_foreign_find|vips_filename|vips_image|vips_init|vips_nick|vips_source_new|vips_source_get_type|vips_target|vips_blob|vips_object|vips_block|vips_operation|vips_type|vips_error|vips_version|vips_leak|vips_shut|vips_cache|vips_array|vips_value|vips_enum|vips_interpolate)[A-Za-z0-9_]*' includes.txt
+  grep -iE ' (_)?(vips_area_copy|vips_area_unref|vips_foreign_find|vips_filename|vips_image|vips_init|vips_nick|vips_source_new|vips_source_get_type|vips_target|vips_blob|vips_object|vips_block|vips_operation|vips_type|vips_error|vips_version|vips_leak|vips_shut|vips_cache|vips_array|vips_value|vips_enum|vips_interpolate)[A-Za-z0-9_]*' includes.txt
   grep -E ' (_)?(VIPS_|VipsTypeMap2Fn)' includes.txt
   grep -iE ' (_)?(GClass|GEnum|GObject|GObjectClass|GInputStream|GInputStreamClass|GTypeInstance|GTypeClass|GValue|GParamSpec|G_TYPE)' includes.txt
   grep -iE ' g_object_(un)?ref|g_free|g_type_from_name|g_type_name|g_param_spec_get_blurb|g_param_spec_types|g_object_set|g_object_get|g_value' includes.txt

--- a/sample/src/main/kotlin/vipsffm/SampleRunner.kt
+++ b/sample/src/main/kotlin/vipsffm/SampleRunner.kt
@@ -21,7 +21,8 @@ object SampleRunner {
             VSourceTargetSample,
             VImageCopyWriteSample,
             VOptionHyphenSample,
-            VImageCachingSample
+            VImageCachingSample,
+            VImageBlobSample
         )
         val sampleParentRunPath = Paths.get("sample_run")
         if (Files.exists(sampleParentRunPath)) {

--- a/sample/src/main/kotlin/vipsffm/VImageBlobSample.kt
+++ b/sample/src/main/kotlin/vipsffm/VImageBlobSample.kt
@@ -1,0 +1,33 @@
+package vipsffm
+
+import app.photofox.vipsffm.VImage
+import app.photofox.vipsffm.VSource
+import app.photofox.vipsffm.VipsHelper
+import java.lang.foreign.Arena
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+
+object VImageBlobSample: RunnableSample {
+
+    // https://github.com/lopcode/vips-ffm/issues/68
+    // tests saving an image to, and loading image from, a buffer
+    // which incorrectly caused a gobject refcount on VipsBlob
+    override fun run(arena: Arena, workingDirectory: Path): Result<Unit> {
+        val outputPath = workingDirectory.resolve("rabbit_blob.jpg")
+        val imageBlob = VImage.newFromFile(
+            arena,
+            "sample/src/main/resources/sample_images/rabbit.jpg"
+        )
+            .thumbnailImage(400)
+            .jpegsaveBuffer()
+
+        VImage.newImage(arena)
+            .jpegloadBuffer(imageBlob)
+            .writeToFile(outputPath.absolutePathString())
+
+        return SampleHelper.validate(
+            outputPath,
+            expectedSizeBoundsKb = 50L..200L
+        )
+    }
+}


### PR DESCRIPTION
Related to #68 - `VipsBlob` is a boxed type which requires different refcount functions