### PR TITLE
Add docker test suite, include debian 12 to start

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,3 +86,23 @@ jobs:
           Get-ChildItem .\vips_w64\vips-dev-8.15
           .\gradlew.bat sample:clean sample:shadowJar
           java -jar sample/build/libs/sample-all.jar
+
+  docker-checks:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: 22
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.10.1
+
+      - name: Run checks
+        run: ./run_docker_tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ hs_err*
 sample_run
 .kotlin
 sample_output*
+sample*.jar

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and [faster](https://github.com/lopcode/vips-ffm/issues/59#issuecomment-23676349
 
 Supports a vast range of image formats, including HEIC, JXL, WebP, PNG, JPEG, and more. Pronounced "vips (like zips)
 eff-eff-emm". The project is relatively new, but aims to be production ready. Tested on macOS 14, Windows 11, and Linux
-(Ubuntu 24.04). Should work on any architecture you can use libvips and Java on (arm64/amd64/etc).
+(Ubuntu 24.04, Debian 12.1). Should work on any architecture you can use libvips and Java on (arm64/amd64/etc).
 
 Used the library? I'd love to hear from more users - let me know in [Discussions](https://github.com/lopcode/vips-ffm/discussions).
 
@@ -152,6 +152,13 @@ To get set up to run samples (on macOS):
 memory: high-water mark 151.24 MB
 [main] INFO vipsffm.SampleRunner - all samples ran successfully 🎉
 ```
+
+### Docker checks
+
+These samples are also run in Docker containers, to verify behaviour on specific Linux distributions. They're useful to
+look at if you're deploying `libvips` and `vips-ffm` workloads using containers.
+
+You can find them in the [`docker_tests`](docker_tests) folder.
 
 ## Native library loading
 

--- a/docker_tests/.gitignore
+++ b/docker_tests/.gitignore
@@ -1,0 +1,2 @@
+*/sample/*
+*/sample/run_samples.sh

--- a/docker_tests/debian-12/Dockerfile
+++ b/docker_tests/debian-12/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:12.1-slim
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:22 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY sample /opt/sample
+COPY run_samples.sh /opt/run_samples.sh
+
+RUN apt update && apt install libvips-dev -y
+
+WORKDIR /opt
+CMD ./run_samples.sh

--- a/run_docker_tests.sh
+++ b/run_docker_tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+echo "building samples..."
+./gradlew sample:clean sample:shadowJar
+
+echo "running docker tests..."
+WORKSPACE_DIR="$PWD"
+
+pushd docker_tests/debian-12
+cp -r "$WORKSPACE_DIR"/sample .
+cp "$WORKSPACE_DIR"/run_samples.sh .
+docker build -t vips-ffm-debian-test .
+docker run vips-ffm-debian-test
+popd

--- a/run_samples.sh
+++ b/run_samples.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
-echo "building samples..."
-./gradlew sample:clean sample:shadowJar
+if [ -f "gradlew" ]; then
+  echo "building samples..."
+  ./gradlew sample:clean sample:shadowJar
+else
+  echo "skipping sample build as no gradle present..."
+fi
 
 export JAVA_PATH_OPTS=""
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
Relates to https://github.com/lopcode/vips-ffm/issues/121

Output:
```
🥕 carrot 🗂  ~/git/vips-ffm 🐙 task/docker-debian-12 $ ./run_docker_tests.sh
building samples...

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.10.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 615ms
6 actionable tasks: 2 executed, 2 from cache, 2 up-to-date
running docker tests...
~/git/vips-ffm/docker_tests/debian-12 ~/git/vips-ffm
[+] Building 0.1s (13/13) FINISHED                                                                                                                docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                              0.0s
 => => transferring dockerfile: 327B                                                                                                                              0.0s
 => WARN: JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 12)                                  0.0s
 => [internal] load metadata for docker.io/library/eclipse-temurin:22                                                                                             0.0s
 => [internal] load metadata for docker.io/library/debian:12.1-slim                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                 0.0s
 => => transferring context: 2B                                                                                                                                   0.0s
 => FROM docker.io/library/eclipse-temurin:22                                                                                                                     0.0s
 => [internal] load build context                                                                                                                                 0.1s
 => => transferring context: 16.91MB                                                                                                                              0.1s
 => [stage-0 1/6] FROM docker.io/library/debian:12.1-slim                                                                                                         0.0s
 => CACHED [stage-0 2/6] COPY --from=eclipse-temurin:22 /opt/java/openjdk /opt/java/openjdk                                                                       0.0s
 => CACHED [stage-0 3/6] COPY sample /opt/sample                                                                                                                  0.0s
 => CACHED [stage-0 4/6] COPY run_samples.sh /opt/run_samples.sh                                                                                                  0.0s
 => CACHED [stage-0 5/6] RUN apt update && apt install libvips-dev -y                                                                                             0.0s
 => CACHED [stage-0 6/6] WORKDIR /opt                                                                                                                             0.0s
 => exporting to image                                                                                                                                            0.0s
 => => exporting layers                                                                                                                                           0.0s
 => => writing image sha256:afae013a770faba7a140f5b3dd6bc8e4ef0f3e6e34967d71393fa2dc87737a18                                                                      0.0s
 => => naming to docker.io/library/vips-ffm-debian-test                                                                                                           0.0s

 1 warning found (use docker --debug to expand):
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 12)

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
skipping sample build as no gradle present...
running samples...
[main] INFO vipsffm.SampleRunner - running sample "RawGetVersionSample"...
[main] INFO vipsffm.sample.RawGetVersionSample - libvips version: "8.14.1"
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "HelperGetVersionSample"...
[main] INFO vipsffm.sample.HelperGetVersionSample - libvips version: "8.14.1"
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VImageCreateThumbnailSample"...
[main] INFO vipsffm.sample.VImageCreateThumbnailSample - source image size: 2490 x 3084
[main] INFO vipsffm.sample.VImageCreateThumbnailSample - thumbnail image size: 323 x 400
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VImageChainSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VSourceTargetSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VImageCopyWriteSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VOptionHyphenSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VImageCachingSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VImageBlobSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VImageArrayJoinSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VBlobByteBufferSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VTargetToFileSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VImageJoinSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VImageFromBytesSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - running sample "VImageStreamSample"...
[main] INFO vipsffm.SampleRunner - validation succeeded ?
[main] INFO vipsffm.SampleRunner - shutting down vips to check for memory leaks...
memory: high-water mark 150.01 MB
[main] INFO vipsffm.SampleRunner - all samples ran successfully ?
vips_threadset_free: peak of 17 threads
checking for leaks...
no leaks detected 🎉
```